### PR TITLE
Update travisTest.sh

### DIFF
--- a/scripts/travisTest.sh
+++ b/scripts/travisTest.sh
@@ -18,7 +18,7 @@ docker build -t `oc registry info`/`oc project -q`/inventory:test inventory/.
 
 oc apply -f ../scripts/test.yaml
 
-sleep 60
+sleep 120
 
 oc get pods
 


### PR DESCRIPTION
Daily build occasionally fails with inventory not detecting system service. Increase timeout in case it needs more time to connect and see if this fixes build. 